### PR TITLE
Board UI: Finish all boards

### DIFF
--- a/project3/connect4_frontend/src/boardgame.rs
+++ b/project3/connect4_frontend/src/boardgame.rs
@@ -31,8 +31,8 @@ impl BoardGame {
         BoardGame {
             board: Board::new(rows, cols),
             count: 0,
-            p1_seq: vec![Chip::Two, Chip::One, Chip::One, Chip::Two],
-            p2_seq: vec![Chip::One, Chip::Two, Chip::Two, Chip::One],
+            p1_seq: vec![Chip::One, Chip::Two, Chip::Two, Chip::One],
+            p2_seq: vec![Chip::Two, Chip::One, Chip::One, Chip::Two],
         }
     }
  

--- a/project3/connect4_frontend/src/boardgame.rs
+++ b/project3/connect4_frontend/src/boardgame.rs
@@ -31,8 +31,8 @@ impl BoardGame {
         BoardGame {
             board: Board::new(rows, cols),
             count: 0,
-            p1_seq: vec![Chip::One, Chip::Two, Chip::Two, Chip::One],
-            p2_seq: vec![Chip::Two, Chip::One, Chip::One, Chip::Two],
+            p1_seq: vec![Chip::Two, Chip::One, Chip::One, Chip::Two],
+            p2_seq: vec![Chip::One, Chip::Two, Chip::Two, Chip::One],
         }
     }
  

--- a/project3/connect4_frontend/src/components/button_input.rs
+++ b/project3/connect4_frontend/src/components/button_input.rs
@@ -4,6 +4,7 @@ use yew::prelude::*;
 pub struct Props {
     pub label: String,
     pub onclick: Callback<()>,
+    pub class: String,
 }
 
 #[function_component(ButtonInput)]
@@ -13,6 +14,6 @@ pub fn button_input(props: &Props) -> Html {
         onclick.emit(());
     });
     html! {
-      <button onclick={button_onclick}>{&props.label}</button>
+      <button onclick={button_onclick} class={props.class.clone()}>{&props.label}</button>
     }
 }

--- a/project3/connect4_frontend/src/components/routes/connect4comp.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4comp.rs
@@ -46,6 +46,7 @@ pub fn connect4_computer_page() -> Html {
                 }
             }
         }
+        // @TODO: need to end callback early if game is over
         let idx = ai.play(&mut data, 1, 5000);
         let res = data.insert(idx, Chip::Two);
         cloned_con4.set(data);
@@ -79,6 +80,7 @@ pub fn connect4_computer_page() -> Html {
             <hr/>
             <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Your Name" />
             <ButtonInput class="btn-start" label="Start Game" onclick={start_game} />
+            // @TODO: Difficulty level
             if *start {
                 <br/>
                 <h3>{format!("New Game: {} Vs {}", &*player1_name, "Computer")}</h3>

--- a/project3/connect4_frontend/src/components/routes/connect4comp.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4comp.rs
@@ -22,6 +22,12 @@ pub fn connect4_computer_page() -> Html {
         cloned_start.set(true);
     });
 
+    let level = use_state(|| 1);
+    let cloned_level = level.clone();
+    let change_level = Callback::from(move |level: usize| {
+        cloned_level.set(level);
+    });
+
     let con4 = use_state(|| BoardGame::connect4(6, 7));
     let over = use_state(|| false);
     let winner = use_state(|| 0);
@@ -31,6 +37,7 @@ pub fn connect4_computer_page() -> Html {
     let cloned_con4 = con4.clone();
     let cloned_over = over.clone();
     let cloned_winner = winner.clone();
+    let cloned_level= level.clone();
     let add_chip = Callback::from(move |col: usize| {
         let mut data = cloned_con4.deref().clone();
         let res = data.insert(col, Chip::One);
@@ -38,26 +45,22 @@ pub fn connect4_computer_page() -> Html {
             if let Some(y) = x {
                 cloned_over.set(true);
                 if y == 1 {
-                    log!("Red wins!");
                     cloned_winner.set(1);
                 } else {
-                    log!("Yellow wins!");
                     cloned_winner.set(2);
                 }
             }
         }
         // @TODO: need to end callback early if game is over
-        let idx = ai.play(&mut data, 1, 5000);
+        let idx = ai.play(&mut data, cloned_level.deref().clone(), 5000);
         let res = data.insert(idx, Chip::Two);
         cloned_con4.set(data);
         if let Ok(x) = res {
             if let Some(y) = x {
                 cloned_over.set(true);
                 if y == 1 {
-                    log!("Red wins!");
                     cloned_winner.set(1);
                 } else {
-                    log!("Yellow wins!");
                     cloned_winner.set(2);
                 }
             }
@@ -80,10 +83,13 @@ pub fn connect4_computer_page() -> Html {
             <hr/>
             <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Your Name" />
             <ButtonInput class="btn-start" label="Start Game" onclick={start_game} />
-            // @TODO: Difficulty level
             if *start {
                 <br/>
                 <h3>{format!("New Game: {} Vs {}", &*player1_name, "Computer")}</h3>
+                <ButtonInput class={if *level == 1 {"btn-start"} else {"btn-normal"}} label="Level 1" onclick={change_level.reform(|_| 1)} />
+                <ButtonInput class={if *level == 2 {"btn-start"} else {"btn-normal"}} label="Level 2" onclick={change_level.reform(|_| 2)} />
+                <ButtonInput class={if *level == 3 {"btn-start"} else {"btn-normal"}} label="Level 3" onclick={change_level.reform(|_| 3)} />
+                <br/>
                 <small>{format!("(Disc Colors: {} - Red and {} - Yellow)", &*player1_name, "Computer")}</small>
                 <br/>
                 if *over {

--- a/project3/connect4_frontend/src/components/routes/connect4comp.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4comp.rs
@@ -16,7 +16,13 @@ pub fn connect4_computer_page() -> Html {
         cloned_player1_name.set(username);
     });
 
-    let con4 = use_state(|| BoardGame::connect4(6, 8));
+    let start = use_state(|| false);
+    let cloned_start = start.clone();
+    let start_game = Callback::from(move |_| {
+        cloned_start.set(true);
+    });
+
+    let con4 = use_state(|| BoardGame::connect4(6, 7));
     let over = use_state(|| false);
     let winner = use_state(|| 0);
 
@@ -69,59 +75,59 @@ pub fn connect4_computer_page() -> Html {
 
     html! {
         <div>
-            <h5 class="w3-xxxlarge w3-text-red"><b>{"Enter Player Names"}</b></h5>
-            <hr style="width:50px;border:5px solid red" class="w3-round"/>
-            <form>
-                // <input id="startbutton" class="button" type="submit" value="Start Game"/> // TODO: create start button
-                <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Player 1's Name" />
-            </form>
-            <br/>
-            <h4>{format!("New Game: {} Vs {}", &*player1_name, "Computer")}</h4>
-            <small>{format!("(Disc Colors: {} - Red and {} - Yellow)", &*player1_name, "Computer")}</small>
-            <br/>
-            if *over {
-                if *winner == 1 {
-                    <p>{format!("{} wins - Click on reset button to start over", &*player1_name)}</p>
+            <h1><b>{"Enter Your Name"}</b></h1>
+            <hr/>
+            <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Your Name" />
+            <ButtonInput class="btn-start" label="Start Game" onclick={start_game} />
+            if *start {
+                <br/>
+                <h3>{format!("New Game: {} Vs {}", &*player1_name, "Computer")}</h3>
+                <small>{format!("(Disc Colors: {} - Red and {} - Yellow)", &*player1_name, "Computer")}</small>
+                <br/>
+                if *over {
+                    if *winner == 1 {
+                        <p>{format!("{} wins - Click on reset button to start over", &*player1_name)}</p>
+                    } else {
+                        <p>{format!("{} wins - Click on reset button to start over", "Computer")}</p>
+                    }
+                    <ButtonInput class="btn-reset" label="Reset" onclick={reset_board} />
                 } else {
-                    <p>{format!("{} wins - Click on reset button to start over", "Computer")}</p>
+                    <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
+                    <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
+                    <ButtonInput class="btn-col" label="2" onclick={add_chip.reform(|_| 2)} />
+                    <ButtonInput class="btn-col" label="3" onclick={add_chip.reform(|_| 3)} />
+                    <ButtonInput class="btn-col" label="4" onclick={add_chip.reform(|_| 4)} />
+                    <ButtonInput class="btn-col" label="5" onclick={add_chip.reform(|_| 5)} />
+                    <ButtonInput class="btn-col" label="6" onclick={add_chip.reform(|_| 6)} />
                 }
-                <ButtonInput label="Reset" onclick={reset_board} />
-            } else {
-                <ButtonInput label="0" onclick={add_chip.reform(|_| 0)} />
-                <ButtonInput label="1" onclick={add_chip.reform(|_| 1)} />
-                <ButtonInput label="2" onclick={add_chip.reform(|_| 2)} />
-                <ButtonInput label="3" onclick={add_chip.reform(|_| 3)} />
-                <ButtonInput label="4" onclick={add_chip.reform(|_| 4)} />
-                <ButtonInput label="5" onclick={add_chip.reform(|_| 5)} />
-                <ButtonInput label="6" onclick={add_chip.reform(|_| 6)} />
-            }
-            
-            <table>
-                { for con4.board.container.iter().map(|inner_vec| {
-                    html! {
-                        <tr>
-                            { for inner_vec.iter().map(|&value| {
-                                if value.is_none() {
-                                    html! {
-                                        <td></td>
-                                    }
-                                } else {
-                                    if value.unwrap() == Chip::One {
+                
+                <table>
+                    { for con4.board.container.iter().map(|inner_vec| {
+                        html! {
+                            <tr>
+                                { for inner_vec.iter().map(|&value| {
+                                    if value.is_none() {
                                         html! {
-                                            <td class="red"><center>{"R"}</center></td>
+                                            <td></td>
                                         }
                                     } else {
-                                        html! {
-                                            <td class="yellow"><center>{"Y"}</center></td>
+                                        if value.unwrap() == Chip::One {
+                                            html! {
+                                                <td class="red"><center>{"R"}</center></td>
+                                            }
+                                        } else {
+                                            html! {
+                                                <td class="yellow"><center>{"Y"}</center></td>
+                                            }
                                         }
                                     }
-                                }
-                                
-                            })}
-                        </tr>
-                    }
-                })}
-            </table>
+                                    
+                                })}
+                            </tr>
+                        }
+                    })}
+                </table>
+            }
         </div>
     }
 }

--- a/project3/connect4_frontend/src/components/routes/connect4comp.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4comp.rs
@@ -6,6 +6,7 @@ use crate::components::text_input::TextInput;
 use crate::components::button_input::ButtonInput;
 use crate::boardgame::*;
 use crate::chip::*;
+use crate::connect4ai::*;
 
 #[function_component(Connect4ComputerPage)]
 pub fn connect4_computer_page() -> Html {
@@ -19,17 +20,28 @@ pub fn connect4_computer_page() -> Html {
     let over = use_state(|| false);
     let winner = use_state(|| 0);
 
+    let mut ai = Connect4AI::new(6);
+
     let cloned_con4 = con4.clone();
     let cloned_over = over.clone();
     let cloned_winner = winner.clone();
     let add_chip = Callback::from(move |col: usize| {
         let mut data = cloned_con4.deref().clone();
-        let chip = if data.board.counter % 2 == 0 {
-            Chip::One
-        } else {
-            Chip::Two
-        };
-        let res = data.insert(col, chip);
+        let res = data.insert(col, Chip::One);
+        if let Ok(x) = res {
+            if let Some(y) = x {
+                cloned_over.set(true);
+                if y == 1 {
+                    log!("Red wins!");
+                    cloned_winner.set(1);
+                } else {
+                    log!("Yellow wins!");
+                    cloned_winner.set(2);
+                }
+            }
+        }
+        let idx = ai.play(&mut data, 1, 5000);
+        let res = data.insert(idx, Chip::Two);
         cloned_con4.set(data);
         if let Ok(x) = res {
             if let Some(y) = x {

--- a/project3/connect4_frontend/src/components/routes/connect4comp.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4comp.rs
@@ -49,9 +49,10 @@ pub fn connect4_computer_page() -> Html {
                 } else {
                     cloned_winner.set(2);
                 }
+                cloned_con4.set(data);
+                return;
             }
         }
-        // @TODO: need to end callback early if game is over
         let idx = ai.play(&mut data, cloned_level.deref().clone(), 5000);
         let res = data.insert(idx, Chip::Two);
         cloned_con4.set(data);
@@ -71,7 +72,7 @@ pub fn connect4_computer_page() -> Html {
     let cloned_over = over.clone();
     let cloned_winner = winner.clone();
     let reset_board = Callback::from(move |_| {
-        let new_board = BoardGame::connect4(6, 8);
+        let new_board = BoardGame::connect4(6, 7);
         cloned_con4.set(new_board);
         cloned_over.set(false);
         cloned_winner.set(0);

--- a/project3/connect4_frontend/src/components/routes/connect4comp.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4comp.rs
@@ -103,10 +103,6 @@ pub fn connect4_computer_page() -> Html {
             if *start {
                 <br/>
                 <h3>{format!("New Game: {} Vs {}", &*player1_name, "Computer")}</h3>
-                <ButtonInput class={if *level == 1 {"btn-start"} else {"btn-normal"}} label="Level 1" onclick={change_level.reform(|_| 1)} />
-                <ButtonInput class={if *level == 2 {"btn-start"} else {"btn-normal"}} label="Level 2" onclick={change_level.reform(|_| 2)} />
-                <ButtonInput class={if *level == 3 {"btn-start"} else {"btn-normal"}} label="Level 3" onclick={change_level.reform(|_| 3)} />
-                <br/>
                 <small>{format!("(Disc Colors: {} - Red and {} - Yellow)", &*player1_name, "Computer")}</small>
                 <br/>
                 if *over {
@@ -117,6 +113,10 @@ pub fn connect4_computer_page() -> Html {
                     }
                     <ButtonInput class="btn-reset" label="Reset" onclick={reset_board} />
                 } else {
+                    <ButtonInput class={if *level == 1 {"btn-start"} else {"btn-normal"}} label="Level 1" onclick={change_level.reform(|_| 1)} />
+                    <ButtonInput class={if *level == 2 {"btn-start"} else {"btn-normal"}} label="Level 2" onclick={change_level.reform(|_| 2)} />
+                    <ButtonInput class={if *level == 3 {"btn-start"} else {"btn-normal"}} label="Level 3" onclick={change_level.reform(|_| 3)} />
+                    <br/>
                     <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
                     <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
                     <ButtonInput class="btn-col" label="2" onclick={add_chip.reform(|_| 2)} />

--- a/project3/connect4_frontend/src/components/routes/connect4comp.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4comp.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 use yew::prelude::*;
-use gloo_console::log;
+use crate::requests::postGame;
 
 use crate::components::text_input::TextInput;
 use crate::components::button_input::ButtonInput;
@@ -38,18 +38,27 @@ pub fn connect4_computer_page() -> Html {
     let cloned_over = over.clone();
     let cloned_winner = winner.clone();
     let cloned_level= level.clone();
+    let cloned_player1_name = player1_name.clone();
     let add_chip = Callback::from(move |col: usize| {
         let mut data = cloned_con4.deref().clone();
         let res = data.insert(col, Chip::One);
         if let Ok(x) = res {
             if let Some(y) = x {
                 cloned_over.set(true);
+                cloned_con4.set(data);
                 if y == 1 {
                     cloned_winner.set(1);
                 } else {
                     cloned_winner.set(2);
                 }
-                cloned_con4.set(data);
+
+                let winner_name = if y == 1 {
+                    cloned_player1_name.deref().clone()
+                } else {
+                    "Computer".to_string()
+                };
+                postGame("connect4".to_string(), cloned_player1_name.deref().clone(), "Computer".to_string(), winner_name, None);
+                
                 return;
             }
         }
@@ -64,6 +73,13 @@ pub fn connect4_computer_page() -> Html {
                 } else {
                     cloned_winner.set(2);
                 }
+
+                let winner_name = if y == 1 {
+                    cloned_player1_name.deref().clone()
+                } else {
+                    "Computer".to_string()
+                };
+                postGame("connect4".to_string(), cloned_player1_name.deref().clone(), "Computer".to_string(), winner_name, None);
             }
         }
     });

--- a/project3/connect4_frontend/src/components/routes/connect4human.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4human.rs
@@ -64,7 +64,7 @@ pub fn connect4_human_page() -> Html {
                 let now = Utc::now();
                 let (is_pm, hour) = now.hour12();
                 let time = format!(
-                    "{:02}/{:02}/{:02} {:02}:{:02}:{:02} {}",
+                    "{:02}/{:02}/{:02} {:02}:{:02}:{:02} {} (UTC)",
                     now.month(),
                     now.day(),
                     now.year(),

--- a/project3/connect4_frontend/src/components/routes/connect4human.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4human.rs
@@ -61,20 +61,7 @@ pub fn connect4_human_page() -> Html {
                     cloned_player2_name.deref().clone()
                 };
 
-                let now = Utc::now();
-                let (is_pm, hour) = now.hour12();
-                let time = format!(
-                    "{:02}/{:02}/{:02} {:02}:{:02}:{:02} {} (UTC)",
-                    now.month(),
-                    now.day(),
-                    now.year(),
-                    hour,
-                    now.minute(),
-                    now.second(),
-                    if is_pm { "PM" } else { "AM" }
-                );
-
-                postGame("connect4".to_string(), cloned_player1_name.deref().clone(), cloned_player2_name.deref().clone(), winner_name, time.to_string(), None);
+                postGame("connect4".to_string(), cloned_player1_name.deref().clone(), cloned_player2_name.deref().clone(), winner_name, None);
             }
         }
     });

--- a/project3/connect4_frontend/src/components/routes/connect4human.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4human.rs
@@ -68,7 +68,7 @@ pub fn connect4_human_page() -> Html {
     let cloned_over = over.clone();
     let cloned_winner = winner.clone();
     let reset_board = Callback::from(move |_| {
-        let new_board = BoardGame::connect4(6, 8);
+        let new_board = BoardGame::connect4(6, 7);
         cloned_con4.set(new_board);
         cloned_over.set(false);
         cloned_winner.set(0);

--- a/project3/connect4_frontend/src/components/routes/connect4human.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4human.rs
@@ -22,7 +22,13 @@ pub fn connect4_human_page() -> Html {
         cloned_player2_name.set(username);
     });
 
-    let con4 = use_state(|| BoardGame::connect4(6, 8));
+    let start = use_state(|| false);
+    let cloned_start = start.clone();
+    let start_game = Callback::from(move |_| {
+        cloned_start.set(true);
+    });
+
+    let con4 = use_state(|| BoardGame::connect4(6, 7));
     let over = use_state(|| false);
     let winner = use_state(|| 0);
 
@@ -85,60 +91,60 @@ pub fn connect4_human_page() -> Html {
 
     html! {
         <div>
-            <h5 class="w3-xxxlarge w3-text-red"><b>{"Enter Player Names"}</b></h5>
-            <hr style="width:50px;border:5px solid red" class="w3-round"/>
-            <form>
-                // <input id="startbutton" class="button" type="submit" value="Start Game"/> // TODO: create start button
-                <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Player 1's Name" />
-                <TextInput handle_onchange={player2_name_changed} id="textbox2" placeholder="Player 2's Name"/>
-            </form>
-            <br/>
-            <h4>{format!("New Game: {} Vs {}", &*player1_name, &*player2_name)}</h4>
-            <small>{format!("(Disc Colors: {} - Red and {} - Yellow)", &*player1_name, &*player2_name)}</small>
-            <br/>
-            if *over {
-                if *winner == 1 {
-                    <p>{format!("{} wins - Click on reset button to start over", &*player1_name)}</p>
+            <h1><b>{"Enter Player Names"}</b></h1>
+            <hr/>
+            <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Player 1's Name" />
+            <TextInput handle_onchange={player2_name_changed} id="textbox2" placeholder="Player 2's Name"/>
+            <ButtonInput class="btn-start" label="Start Game" onclick={start_game} />
+            if *start {
+                <br/>
+                <h3>{format!("New Game: {} Vs {}", &*player1_name, &*player2_name)}</h3>
+                <small>{format!("(Disc Colors: {} - Red and {} - Yellow)", &*player1_name, &*player2_name)}</small>
+                <br/>
+                if *over {
+                    if *winner == 1 {
+                        <p>{format!("{} wins - Click on reset button to start over", &*player1_name)}</p>
+                    } else {
+                        <p>{format!("{} wins - Click on reset button to start over", &*player2_name)}</p>
+                    }
+                    <ButtonInput class="btn-reset" label="Reset" onclick={reset_board} />
                 } else {
-                    <p>{format!("{} wins - Click on reset button to start over", &*player2_name)}</p>
+                    <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
+                    <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
+                    <ButtonInput class="btn-col" label="2" onclick={add_chip.reform(|_| 2)} />
+                    <ButtonInput class="btn-col" label="3" onclick={add_chip.reform(|_| 3)} />
+                    <ButtonInput class="btn-col" label="4" onclick={add_chip.reform(|_| 4)} />
+                    <ButtonInput class="btn-col" label="5" onclick={add_chip.reform(|_| 5)} />
+                    <ButtonInput class="btn-col" label="6" onclick={add_chip.reform(|_| 6)} />
                 }
-                <ButtonInput class="" label="Reset" onclick={reset_board} />
-            } else {
-                <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
-                <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
-                <ButtonInput class="btn-col" label="2" onclick={add_chip.reform(|_| 2)} />
-                <ButtonInput class="btn-col" label="3" onclick={add_chip.reform(|_| 3)} />
-                <ButtonInput class="btn-col" label="4" onclick={add_chip.reform(|_| 4)} />
-                <ButtonInput class="btn-col" label="5" onclick={add_chip.reform(|_| 5)} />
-                <ButtonInput class="btn-col" label="6" onclick={add_chip.reform(|_| 6)} />
-            }
-            
-            <table>
-                { for con4.board.container.iter().map(|inner_vec| {
-                    html! {
-                        <tr>
-                            { for inner_vec.iter().map(|&value| {
-                                if value.is_none() {
-                                    html! {
-                                        <td></td>
-                                    }
-                                } else {
-                                    if value.unwrap() == Chip::One {
+                
+                <table>
+                    { for con4.board.container.iter().map(|inner_vec| {
+                        html! {
+                            <tr>
+                                { for inner_vec.iter().map(|&value| {
+                                    if value.is_none() {
                                         html! {
-                                            <td class="red"><center>{"R"}</center></td>
+                                            <td></td>
                                         }
                                     } else {
-                                        html! {
-                                            <td class="yellow"><center>{"Y"}</center></td>
+                                        if value.unwrap() == Chip::One {
+                                            html! {
+                                                <td class="red"><center>{"R"}</center></td>
+                                            }
+                                        } else {
+                                            html! {
+                                                <td class="yellow"><center>{"Y"}</center></td>
+                                            }
                                         }
                                     }
-                                }
-                                
-                            })}
-                        </tr>
-                    }
-                })}
-            </table>
+                                    
+                                })}
+                            </tr>
+                        }
+                    })}
+                </table>
+            }
         </div>
     }
 }

--- a/project3/connect4_frontend/src/components/routes/connect4human.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4human.rs
@@ -102,15 +102,15 @@ pub fn connect4_human_page() -> Html {
                 } else {
                     <p>{format!("{} wins - Click on reset button to start over", &*player2_name)}</p>
                 }
-                <ButtonInput label="Reset" onclick={reset_board} />
+                <ButtonInput class="" label="Reset" onclick={reset_board} />
             } else {
-                <ButtonInput label="0" onclick={add_chip.reform(|_| 0)} />
-                <ButtonInput label="1" onclick={add_chip.reform(|_| 1)} />
-                <ButtonInput label="2" onclick={add_chip.reform(|_| 2)} />
-                <ButtonInput label="3" onclick={add_chip.reform(|_| 3)} />
-                <ButtonInput label="4" onclick={add_chip.reform(|_| 4)} />
-                <ButtonInput label="5" onclick={add_chip.reform(|_| 5)} />
-                <ButtonInput label="6" onclick={add_chip.reform(|_| 6)} />
+                <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
+                <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
+                <ButtonInput class="btn-col" label="2" onclick={add_chip.reform(|_| 2)} />
+                <ButtonInput class="btn-col" label="3" onclick={add_chip.reform(|_| 3)} />
+                <ButtonInput class="btn-col" label="4" onclick={add_chip.reform(|_| 4)} />
+                <ButtonInput class="btn-col" label="5" onclick={add_chip.reform(|_| 5)} />
+                <ButtonInput class="btn-col" label="6" onclick={add_chip.reform(|_| 6)} />
             }
             
             <table>

--- a/project3/connect4_frontend/src/components/routes/connect4human.rs
+++ b/project3/connect4_frontend/src/components/routes/connect4human.rs
@@ -1,6 +1,5 @@
 use std::ops::Deref;
 use yew::prelude::*;
-use chrono::{Datelike, Timelike, Utc};
 
 use crate::components::text_input::TextInput;
 use crate::components::button_input::ButtonInput;
@@ -60,7 +59,6 @@ pub fn connect4_human_page() -> Html {
                 } else {
                     cloned_player2_name.deref().clone()
                 };
-
                 postGame("connect4".to_string(), cloned_player1_name.deref().clone(), cloned_player2_name.deref().clone(), winner_name, None);
             }
         }

--- a/project3/connect4_frontend/src/components/routes/ottoComp.rs
+++ b/project3/connect4_frontend/src/components/routes/ottoComp.rs
@@ -1,5 +1,165 @@
+use std::ops::Deref;
 use yew::prelude::*;
-#[function_component]
-pub fn OttoCompPage() -> Html {
-    html! {<h1>{"otto computer"}</h1>}
+use crate::requests::postGame;
+
+use crate::components::text_input::TextInput;
+use crate::components::button_input::ButtonInput;
+use crate::boardgame::*;
+use crate::chip::*;
+use crate::toai::*;
+
+#[function_component(OttoCompPage)]
+pub fn otto_comp_page() -> Html {
+    let player1_name = use_state(|| "Player 1".to_owned());
+    let cloned_player1_name = player1_name.clone();
+    let player1_name_changed = Callback::from(move |username: String| {
+        cloned_player1_name.set(username);
+    });
+
+    let chip_type = use_state(|| Chip::One);
+    let cloned_chip_type = chip_type.clone();
+    let change_chip_type = Callback::from(move |chip: Chip| {
+        cloned_chip_type.set(chip);
+    });
+
+    let start = use_state(|| false);
+    let cloned_start = start.clone();
+    let start_game = Callback::from(move |_| {
+        cloned_start.set(true);
+    });
+
+    let level = use_state(|| 1);
+    let cloned_level = level.clone();
+    let change_level = Callback::from(move |level: usize| {
+        cloned_level.set(level);
+    });
+
+    let toot_otto = use_state(|| BoardGame::toot_otto(6, 7));
+    let over = use_state(|| false);
+    let winner = use_state(|| 0);
+
+    let mut ai = TootOttoAI::new();
+
+    let cloned_toot_otto = toot_otto.clone();
+    let cloned_over = over.clone();
+    let cloned_winner = winner.clone();
+    let cloned_level= level.clone();
+    let cloned_player1_name = player1_name.clone();
+    let cloned_chip_type = chip_type.clone();
+    let add_chip = Callback::from(move |col: usize| {
+        let mut data = cloned_toot_otto.deref().clone();
+        let chip = cloned_chip_type.deref().clone();
+        let res = data.insert(col, chip);
+        if let Ok(x) = res {
+            if let Some(y) = x {
+                cloned_over.set(true);
+                cloned_toot_otto.set(data);
+                if y == 1 {
+                    cloned_winner.set(1);
+                } else {
+                    cloned_winner.set(2);
+                }
+
+                let winner_name = if y == 1 {
+                    cloned_player1_name.deref().clone()
+                } else {
+                    "Computer".to_string()
+                };
+                postGame("toot otto".to_string(), cloned_player1_name.deref().clone(), "Computer".to_string(), winner_name, None);
+                
+                return;
+            }
+        }
+        let (idx, chip) = ai.play(&mut data, cloned_level.deref().clone(), 2500);
+        let res = data.insert(idx, chip);
+        cloned_toot_otto.set(data);
+        if let Ok(x) = res {
+            if let Some(y) = x {
+                cloned_over.set(true);
+                if y == 1 {
+                    cloned_winner.set(1);
+                } else {
+                    cloned_winner.set(2);
+                }
+
+                let winner_name = if y == 1 {
+                    cloned_player1_name.deref().clone()
+                } else {
+                    "Computer".to_string()
+                };
+                postGame("toot otto".to_string(), cloned_player1_name.deref().clone(), "Computer".to_string(), winner_name, None);
+            }
+        }
+    });
+
+    let cloned_toot_otto = toot_otto.clone();
+    let cloned_over = over.clone();
+    let cloned_winner = winner.clone();
+    let reset_board = Callback::from(move |_| {
+        let new_board = BoardGame::toot_otto(6, 7);
+        cloned_toot_otto.set(new_board);
+        cloned_over.set(false);
+        cloned_winner.set(0);
+    });
+
+    html! {
+        <div>
+            <h1><b>{"Enter Your Name"}</b></h1>
+            <hr/>
+            <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Your Name" />
+            <ButtonInput class="btn-start" label="Start Game" onclick={start_game} />
+            if *start {
+                <br/>
+                <h3>{format!("New Game: {} Vs {}", &*player1_name, "Computer")}</h3>
+                <small>{format!("(Disc Colors: {} - TOOT and {} - OTTO)", &*player1_name, "Computer")}</small>
+                <br/>
+                if *over {
+                    if *winner == 1 {
+                        <p>{format!("{} wins - Click on reset button to start over", &*player1_name)}</p>
+                    } else {
+                        <p>{format!("{} wins - Click on reset button to start over", "Computer")}</p>
+                    }
+                    <ButtonInput class="btn-reset" label="Reset" onclick={reset_board} />
+                } else {
+                    <ButtonInput class={if *chip_type == Chip::One {"btn-start"} else {"btn-normal"}} label="T" onclick={change_chip_type.reform(|_| Chip::One)} />
+                    <ButtonInput class={if *chip_type == Chip::Two {"btn-start"} else {"btn-normal"}} label="O" onclick={change_chip_type.reform(|_| Chip::Two)} />
+                    <br/>
+                    <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
+                    <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
+                    <ButtonInput class="btn-col" label="2" onclick={add_chip.reform(|_| 2)} />
+                    <ButtonInput class="btn-col" label="3" onclick={add_chip.reform(|_| 3)} />
+                    <ButtonInput class="btn-col" label="4" onclick={add_chip.reform(|_| 4)} />
+                    <ButtonInput class="btn-col" label="5" onclick={add_chip.reform(|_| 5)} />
+                    <ButtonInput class="btn-col" label="6" onclick={add_chip.reform(|_| 6)} />
+                }
+                
+                <table>
+                    { for toot_otto.board.container.iter().map(|inner_vec| {
+                        html! {
+                            <tr>
+                                { for inner_vec.iter().map(|&value| {
+                                    if value.is_none() {
+                                        html! {
+                                            <td></td>
+                                        }
+                                    } else {
+                                        if value.unwrap() == Chip::One {
+                                            html! {
+                                                <td class="red"><center>{"T"}</center></td>
+                                            }
+                                        } else {
+                                            html! {
+                                                <td class="yellow"><center>{"O"}</center></td>
+                                            }
+                                        }
+                                    }
+                                    
+                                })}
+                            </tr>
+                        }
+                    })}
+                </table>
+            }
+        </div>
+    }
 }

--- a/project3/connect4_frontend/src/components/routes/ottoComp.rs
+++ b/project3/connect4_frontend/src/components/routes/ottoComp.rs
@@ -121,6 +121,11 @@ pub fn otto_comp_page() -> Html {
                     }
                     <ButtonInput class="btn-reset" label="Reset" onclick={reset_board} />
                 } else {
+                    <ButtonInput class={if *level == 1 {"btn-start"} else {"btn-normal"}} label="Level 1" onclick={change_level.reform(|_| 1)} />
+                    <ButtonInput class={if *level == 2 {"btn-start"} else {"btn-normal"}} label="Level 2" onclick={change_level.reform(|_| 2)} />
+                    <ButtonInput class={if *level == 3 {"btn-start"} else {"btn-normal"}} label="Level 3" onclick={change_level.reform(|_| 3)} />
+                    <br/>
+                    <br/>
                     <ButtonInput class={if *chip_type == Chip::One {"btn-start"} else {"btn-normal"}} label="T" onclick={change_chip_type.reform(|_| Chip::One)} />
                     <ButtonInput class={if *chip_type == Chip::Two {"btn-start"} else {"btn-normal"}} label="O" onclick={change_chip_type.reform(|_| Chip::Two)} />
                     <br/>

--- a/project3/connect4_frontend/src/components/routes/ottoComp.rs
+++ b/project3/connect4_frontend/src/components/routes/ottoComp.rs
@@ -16,7 +16,7 @@ pub fn otto_comp_page() -> Html {
         cloned_player1_name.set(username);
     });
 
-    let chip_type = use_state(|| Chip::One);
+    let chip_type = use_state(|| Chip::Two);
     let cloned_chip_type = chip_type.clone();
     let change_chip_type = Callback::from(move |chip: Chip| {
         cloned_chip_type.set(chip);
@@ -126,8 +126,8 @@ pub fn otto_comp_page() -> Html {
                     <ButtonInput class={if *level == 3 {"btn-start"} else {"btn-normal"}} label="Level 3" onclick={change_level.reform(|_| 3)} />
                     <br/>
                     <br/>
-                    <ButtonInput class={if *chip_type == Chip::One {"btn-start"} else {"btn-normal"}} label="T" onclick={change_chip_type.reform(|_| Chip::One)} />
-                    <ButtonInput class={if *chip_type == Chip::Two {"btn-start"} else {"btn-normal"}} label="O" onclick={change_chip_type.reform(|_| Chip::Two)} />
+                    <ButtonInput class={if *chip_type == Chip::Two {"btn-start"} else {"btn-normal"}} label="T" onclick={change_chip_type.reform(|_| Chip::Two)} />
+                    <ButtonInput class={if *chip_type == Chip::One {"btn-start"} else {"btn-normal"}} label="O" onclick={change_chip_type.reform(|_| Chip::One)} />
                     <br/>
                     <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
                     <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
@@ -150,11 +150,11 @@ pub fn otto_comp_page() -> Html {
                                     } else {
                                         if value.unwrap() == Chip::One {
                                             html! {
-                                                <td class="red"><center>{"T"}</center></td>
+                                                <td class="yellow"><center>{"O"}</center></td>
                                             }
                                         } else {
                                             html! {
-                                                <td class="yellow"><center>{"O"}</center></td>
+                                                <td class="red"><center>{"T"}</center></td>
                                             }
                                         }
                                     }

--- a/project3/connect4_frontend/src/components/routes/ottoHuman.rs
+++ b/project3/connect4_frontend/src/components/routes/ottoHuman.rs
@@ -21,7 +21,7 @@ pub fn otto_human_page() -> Html {
         cloned_player2_name.set(username);
     });
 
-    let chip_type = use_state(|| Chip::One);
+    let chip_type = use_state(|| Chip::Two);
     let cloned_chip_type = chip_type.clone();
     let change_chip_type = Callback::from(move |chip: Chip| {
         cloned_chip_type.set(chip);
@@ -97,8 +97,8 @@ pub fn otto_human_page() -> Html {
                     }
                     <ButtonInput class="btn-reset" label="Reset" onclick={reset_board} />
                 } else {
-                    <ButtonInput class={if *chip_type == Chip::One {"btn-start"} else {"btn-normal"}} label="T" onclick={change_chip_type.reform(|_| Chip::One)} />
-                    <ButtonInput class={if *chip_type == Chip::Two {"btn-start"} else {"btn-normal"}} label="O" onclick={change_chip_type.reform(|_| Chip::Two)} />
+                    <ButtonInput class={if *chip_type == Chip::Two {"btn-start"} else {"btn-normal"}} label="T" onclick={change_chip_type.reform(|_| Chip::Two)} />
+                    <ButtonInput class={if *chip_type == Chip::One {"btn-start"} else {"btn-normal"}} label="O" onclick={change_chip_type.reform(|_| Chip::One)} />
                     <br/>
                     <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
                     <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
@@ -121,11 +121,11 @@ pub fn otto_human_page() -> Html {
                                     } else {
                                         if value.unwrap() == Chip::One {
                                             html! {
-                                                <td class="red"><center>{"T"}</center></td>
+                                                <td class="yellow"><center>{"O"}</center></td>
                                             }
                                         } else {
                                             html! {
-                                                <td class="yellow"><center>{"O"}</center></td>
+                                                <td class="red"><center>{"T"}</center></td>
                                             }
                                         }
                                     }

--- a/project3/connect4_frontend/src/components/routes/ottoHuman.rs
+++ b/project3/connect4_frontend/src/components/routes/ottoHuman.rs
@@ -1,6 +1,11 @@
+use std::ops::Deref;
 use yew::prelude::*;
 
 use crate::components::text_input::TextInput;
+use crate::components::button_input::ButtonInput;
+use crate::boardgame::*;
+use crate::chip::*;
+use crate::requests::postGame;
 
 #[function_component(OttoHumanPage)]
 pub fn otto_human_page() -> Html {
@@ -16,25 +21,121 @@ pub fn otto_human_page() -> Html {
         cloned_player2_name.set(username);
     });
 
+    let chip_type = use_state(|| Chip::One);
+    let cloned_chip_type = chip_type.clone();
+    let change_chip_type = Callback::from(move |chip: Chip| {
+        cloned_chip_type.set(chip);
+    });
+
+    let start = use_state(|| false);
+    let cloned_start = start.clone();
+    let start_game = Callback::from(move |_| {
+        cloned_start.set(true);
+    });
+
+    let toot_otto = use_state(|| BoardGame::toot_otto(6, 7));
+    let over = use_state(|| false);
+    let winner = use_state(|| 0);
+
+    let cloned_toot_otto = toot_otto.clone();
+    let cloned_over = over.clone();
+    let cloned_winner = winner.clone();
+    let cloned_player1_name = player1_name.clone();
+    let cloned_player2_name = player2_name.clone();
+    let cloned_chip_type = chip_type.clone();
+    let add_chip = Callback::from(move |col: usize| {
+        let mut data = cloned_toot_otto.deref().clone();
+        let chip = cloned_chip_type.deref().clone();
+        let res = data.insert(col, chip);
+        cloned_toot_otto.set(data);
+        if let Ok(x) = res {
+            if let Some(y) = x {
+                cloned_over.set(true);
+                if y == 1 {
+                    cloned_winner.set(1);
+                } else {
+                    cloned_winner.set(2);
+                }
+
+                let winner_name = if y == 1 {
+                    cloned_player1_name.deref().clone()
+                } else {
+                    cloned_player2_name.deref().clone()
+                };
+                postGame("connect4".to_string(), cloned_player1_name.deref().clone(), cloned_player2_name.deref().clone(), winner_name, None);
+            }
+        }
+    });
+
+    let cloned_toot_otto = toot_otto.clone();
+    let cloned_over = over.clone();
+    let cloned_winner = winner.clone();
+    let reset_board = Callback::from(move |_| {
+        let new_board = BoardGame::connect4(6, 8);
+        cloned_toot_otto.set(new_board);
+        cloned_over.set(false);
+        cloned_winner.set(0);
+    });
+
     html! {
         <div>
-            <h5 class="w3-xxxlarge w3-text-red"><b>{"Enter Player Names"}</b></h5>
-            <hr style="width:50px;border:5px solid red" class="w3-round"/>
-            <form>
-                // <input id="startbutton" class="button" type="submit" value="Start Game"/> // TODO: create start button
-                <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Player 1's Name" />
-                <TextInput handle_onchange={player2_name_changed} id="textbox2" placeholder="Player 2's Name"/>
-            </form>
-            <br/>
-            <h4>{format!("New Game: {} Vs {}", &*player1_name, &*player2_name)}</h4>
-            <small>{format!("(Winning Combination: {} - TOOT and {} - OTTO)", &*player1_name, &*player2_name)}</small>
-            <br/>
-            <form>
-                <h4>{"Select a Disc Type    :"}</h4>
-                <input type="radio" name="choice" value="T"/> <span>{"T"}</span>
-                <input type="radio" name="choice" value="O"/> <span>{"O"}</span>
-            </form>
-            <canvas id="gameboard" height="480" width="640"></canvas>
+            <h1><b>{"Enter Player Names"}</b></h1>
+            <hr/>
+            <TextInput handle_onchange={player1_name_changed} id="textbox1" placeholder="Player 1's Name" />
+            <TextInput handle_onchange={player2_name_changed} id="textbox2" placeholder="Player 2's Name"/>
+            <ButtonInput class="btn-start" label="Start Game" onclick={start_game} />
+            if *start {
+                <br/>
+                <h3>{format!("New Game: {} Vs {}", &*player1_name, &*player2_name)}</h3>
+                <small>{format!("(Disc Colors: {} - TOOT and {} - OTTO)", &*player1_name, &*player2_name)}</small>
+                <br/>
+                if *over {
+                    if *winner == 1 {
+                        <p>{format!("{} wins - Click on reset button to start over", &*player1_name)}</p>
+                    } else {
+                        <p>{format!("{} wins - Click on reset button to start over", &*player2_name)}</p>
+                    }
+                    <ButtonInput class="btn-reset" label="Reset" onclick={reset_board} />
+                } else {
+                    <ButtonInput class={if *chip_type == Chip::One {"btn-start"} else {"btn-normal"}} label="T" onclick={change_chip_type.reform(|_| Chip::One)} />
+                    <ButtonInput class={if *chip_type == Chip::Two {"btn-start"} else {"btn-normal"}} label="O" onclick={change_chip_type.reform(|_| Chip::Two)} />
+                    <br/>
+                    <ButtonInput class="btn-col" label="0" onclick={add_chip.reform(|_| 0)} />
+                    <ButtonInput class="btn-col" label="1" onclick={add_chip.reform(|_| 1)} />
+                    <ButtonInput class="btn-col" label="2" onclick={add_chip.reform(|_| 2)} />
+                    <ButtonInput class="btn-col" label="3" onclick={add_chip.reform(|_| 3)} />
+                    <ButtonInput class="btn-col" label="4" onclick={add_chip.reform(|_| 4)} />
+                    <ButtonInput class="btn-col" label="5" onclick={add_chip.reform(|_| 5)} />
+                    <ButtonInput class="btn-col" label="6" onclick={add_chip.reform(|_| 6)} />
+                }
+                
+                <table>
+                    { for toot_otto.board.container.iter().map(|inner_vec| {
+                        html! {
+                            <tr>
+                                { for inner_vec.iter().map(|&value| {
+                                    if value.is_none() {
+                                        html! {
+                                            <td></td>
+                                        }
+                                    } else {
+                                        if value.unwrap() == Chip::One {
+                                            html! {
+                                                <td class="red"><center>{"T"}</center></td>
+                                            }
+                                        } else {
+                                            html! {
+                                                <td class="yellow"><center>{"O"}</center></td>
+                                            }
+                                        }
+                                    }
+                                    
+                                })}
+                            </tr>
+                        }
+                    })}
+                </table>
+            }
         </div>
     }
 }

--- a/project3/connect4_frontend/src/components/routes/ottoHuman.rs
+++ b/project3/connect4_frontend/src/components/routes/ottoHuman.rs
@@ -62,7 +62,7 @@ pub fn otto_human_page() -> Html {
                 } else {
                     cloned_player2_name.deref().clone()
                 };
-                postGame("connect4".to_string(), cloned_player1_name.deref().clone(), cloned_player2_name.deref().clone(), winner_name, None);
+                postGame("toot otto".to_string(), cloned_player1_name.deref().clone(), cloned_player2_name.deref().clone(), winner_name, None);
             }
         }
     });

--- a/project3/connect4_frontend/src/components/routes/ottoHuman.rs
+++ b/project3/connect4_frontend/src/components/routes/ottoHuman.rs
@@ -71,7 +71,7 @@ pub fn otto_human_page() -> Html {
     let cloned_over = over.clone();
     let cloned_winner = winner.clone();
     let reset_board = Callback::from(move |_| {
-        let new_board = BoardGame::connect4(6, 8);
+        let new_board = BoardGame::toot_otto(6, 7);
         cloned_toot_otto.set(new_board);
         cloned_over.set(false);
         cloned_winner.set(0);

--- a/project3/connect4_frontend/src/requests.rs
+++ b/project3/connect4_frontend/src/requests.rs
@@ -1,6 +1,7 @@
 use crate::models::*;
 use serde::Deserialize;
 use yew::prelude::*;
+use chrono::{Datelike, Timelike, Utc};
 
 // ====================== POSTS ============================
 async fn postGameAsync(
@@ -44,7 +45,6 @@ pub fn postGame(
     player_1_name: String,
     player_2_name: String,
     winner_name: String,
-    game_date: String,
     errCallback: Option<Callback<()>>,
 ){  
     // has one level of indirection to prevent the need for
@@ -53,7 +53,7 @@ pub fn postGame(
         player_1_name,
         player_2_name,
         winner_name,
-        game_date,
+        get_time(),
         errCallback));
 }
 
@@ -190,4 +190,21 @@ pub fn initiateScoresRequests(
     setHasRequested.emit(()); 
     wasm_bindgen_futures::spawn_local(updateScores(
     setCompGames,setCompMetrics,setScores,setFail,setFinishedRequest));
+}
+
+// ====================== UTILITIES ============================
+fn get_time() -> String {
+    let now = Utc::now();
+    let (is_pm, hour) = now.hour12();
+    let time = format!(
+        "{:02}/{:02}/{:02} {:02}:{:02}:{:02} {} (UTC)",
+        now.month(),
+        now.day(),
+        now.year(),
+        hour,
+        now.minute(),
+        now.second(),
+        if is_pm { "PM" } else { "AM" }
+    );
+    time
 }

--- a/project3/connect4_frontend/src/styles/global.css
+++ b/project3/connect4_frontend/src/styles/global.css
@@ -58,4 +58,5 @@ input {
   height: 30px;
   width: 200px;
   border-radius: 7px 7px 7px 7px;
+  margin-right: 5px;
 }

--- a/project3/connect4_frontend/src/styles/global.css
+++ b/project3/connect4_frontend/src/styles/global.css
@@ -20,3 +20,42 @@ td {
 .yellow {
   background-color: yellow;
 }
+
+hr {
+  border: 5px solid #3477aa;
+  width: 50px;
+  margin-left: 0;
+  margin-bottom: 20px;
+  border-radius: 7px 7px 7px 7px;
+}
+
+h1 {
+  color: #3477aa;
+  font-size: 50px;
+}
+
+.btn-col {
+  background-color: #3477aa;
+  color: white;
+  width: 33px;
+}
+
+.btn-reset {
+  background-color: #3477aa;
+  color: white;
+  width: 231px;
+}
+
+.btn-start {
+  height: 37px;
+  background-color: #3477aa;
+  color: white;
+  margin-left: 5px;
+  border-radius: 7px 7px 7px 7px;
+}
+
+input {
+  height: 30px;
+  width: 200px;
+  border-radius: 7px 7px 7px 7px;
+}

--- a/project3/connect4_frontend/src/styles/global.css
+++ b/project3/connect4_frontend/src/styles/global.css
@@ -54,6 +54,12 @@ h1 {
   border-radius: 7px 7px 7px 7px;
 }
 
+.btn-normal {
+  height: 37px;
+  margin-left: 5px;
+  border-radius: 7px 7px 7px 7px;
+}
+
 input {
   height: 30px;
   width: 200px;


### PR DESCRIPTION
# Main Changes
- Complete all boards: toot otto human, toot otto ai, connect4 ai, connect4 human
- Style the page to match the MEAN example
- add difficulty-level buttons to the ai page 
- connect all pages to database

# Missing Functionality
- Frontend can be refactored to be more reusable and extendable
- We don't track which player made which moves so we can't visually mark it based on that (as they do in the MEAN implementation). I don't think it's worth implementing this but I already noted it down in the report.

# Demo
- Toot Otto human
[toot-human.webm](https://user-images.githubusercontent.com/29143314/230651217-8deb9a75-3cb0-4da4-902a-5b5d96cf73b3.webm)
- Toot Otto ai
[toot-ai.webm](https://user-images.githubusercontent.com/29143314/230651233-014aa5ae-1a07-4d00-96bf-56af7adeddbc.webm)
- connect4 human
[connect4-human.webm](https://user-images.githubusercontent.com/29143314/230651286-dd20328c-742c-434a-891c-9b76693cbedb.webm)
- connect4 ai
[connect4-ai.webm](https://user-images.githubusercontent.com/29143314/230651303-259c1a5d-dd74-465e-ba87-ca738224901a.webm)
